### PR TITLE
Add fly.io app configuration: `boggle.fly.dev`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+# flyctl launch added from .gitignore
+**/*.boggle
+**/.ssh
+# Experimental outputs.
+**/data
+fly.toml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+ARG GO_VERSION=1
+FROM golang:${GO_VERSION}-bookworm as builder
+
+WORKDIR /usr/src/app
+COPY go.mod go.sum ./
+RUN go mod download && go mod verify
+COPY . .
+RUN go build -v -o /run-app ./cmd/wish
+
+
+FROM debian:bookworm
+
+COPY --from=builder /run-app /usr/local/bin/
+CMD ["run-app"]

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A TUI game of single-player boggle inspired by [wordshake.com/boggle](https://wordshake.com/boggle).
 
+Play a hosted game: `ssh boggle.fly.dev`.
+
 ## Installation
 
 ```console

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,30 @@
+# fly.toml app configuration file generated for boggle on 2024-12-15T21:12:15-08:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = 'boggle'
+primary_region = 'sjc'
+
+[build]
+  [build.args]
+    GO_VERSION = '1.23'
+
+[[services]]
+  internal_port = 23234
+  protocol = "tcp"
+  auto_stop_machines = true
+  auto_start_machines = true
+  [[services.ports]]
+    port = 22
+
+[env]
+  SSH_KEY_PATH = "/data/boggle_ed25519"
+
+[[vm]]
+  size = 'shared-cpu-1x'
+
+[mounts]
+  source = "ssh_key"
+  destination = "/data"
+


### PR DESCRIPTION
Adds ugly fly.io configuration for deploying `./cmd/wish` to the open web. Isolated from #1 to make this portion easier to revert upon app spindown.

The relevant credentials are backed up where I'd expect to find them.