### PR TITLE
fix(dice): correct EEINSV die to EEINSU

### DIFF
--- a/pkg/boggle/die.go
+++ b/pkg/boggle/die.go
@@ -63,7 +63,7 @@ var (
 	newDie7  = newDie{"d", "e", "l", "r", "v", "y"}
 	newDie8  = newDie{"d", "i", "s", "t", "t", "y"}
 	newDie9  = newDie{"e", "e", "g", "h", "n", "w"}
-	newDie10 = newDie{"e", "e", "i", "n", "s", "v"}
+	newDie10 = newDie{"e", "e", "i", "n", "s", "u"}
 	newDie11 = newDie{"e", "h", "r", "t", "v", "w"}
 	newDie12 = newDie{"e", "i", "o", "s", "s", "t"}
 	newDie13 = newDie{"e", "l", "r", "t", "t", "y"}


### PR DESCRIPTION
Fixes #10. The new die set's die 10 should be EEINSU, not EEINSV. See [this StackExchange correction](https://boardgames.stackexchange.com/questions/29264/boggle-what-is-the-dice-configuration-for-boggle-in-various-languages/61722#comment95841_61722).