### PR TITLE
Add -version flag to CLI and wish binaries

### DIFF
--- a/cmd/wish/main.go
+++ b/cmd/wish/main.go
@@ -2,10 +2,14 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"flag"
+	"fmt"
 	"net"
 	"os"
 	"os/signal"
+	"runtime/debug"
 	"syscall"
 	"time"
 
@@ -27,6 +31,32 @@ const (
 )
 
 func main() {
+	version := flag.Bool("version", false, "Display tool version info (JSON)")
+	flag.Parse()
+
+	if *version {
+		info, ok := debug.ReadBuildInfo()
+		if !ok {
+			fmt.Println("Error reading build info")
+			os.Exit(1)
+		}
+		settings := make(map[string]string, len(info.Settings))
+		for _, pair := range info.Settings {
+			settings[pair.Key] = pair.Value
+		}
+		b, err := json.MarshalIndent(map[string]any{
+			"go":       info.GoVersion,
+			"path":     info.Path,
+			"settings": settings,
+		}, "", "\t")
+		if err != nil {
+			fmt.Printf("Error marshaling build info: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println(string(b))
+		os.Exit(0)
+	}
+
 	// Key is coupled to fly.toml.
 	hostKeyPath, ok := os.LookupEnv("SSH_KEY_PATH")
 	if !ok {

--- a/main.go
+++ b/main.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
+	"os"
+	"runtime/debug"
 	"sort"
 	"time"
 
@@ -31,6 +34,7 @@ The following options are available:
 `
 
 func main() {
+	version := flag.Bool("version", false, "Display tool version info (JSON)")
 	var filenameFlag = flag.String("file", "", ".boggle file to configure game")
 	var boardFlag = flag.String("board", "", "serialized board string")
 	var boardUrlFlag = flag.String("url", "", "web URL of a public .boggle file to configure game")
@@ -44,6 +48,29 @@ func main() {
 		flag.PrintDefaults()
 	}
 	flag.Parse()
+
+	if *version {
+		info, ok := debug.ReadBuildInfo()
+		if !ok {
+			fmt.Println("Error reading build info")
+			os.Exit(1)
+		}
+		settings := make(map[string]string, len(info.Settings))
+		for _, pair := range info.Settings {
+			settings[pair.Key] = pair.Value
+		}
+		b, err := json.MarshalIndent(map[string]any{
+			"go":       info.GoVersion,
+			"path":     info.Path,
+			"settings": settings,
+		}, "", "\t")
+		if err != nil {
+			fmt.Printf("Error marshaling build info: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println(string(b))
+		return
+	}
 
 	dice := boggle.ClassicDice
 	if *newFlag {


### PR DESCRIPTION
Adds a `-version` flag to both the CLI (`boggle`) and SSH server (`cmd/wish`) binaries.

When passed, prints JSON build info (Go version, module path, VCS settings) and exits.

Modeled on:
- https://github.com/lukasschwab/feedcel/commit/8fb56b7
- https://github.com/lukasschwab/reader/commit/5bbc467